### PR TITLE
Add recipe to grind zinc into zinc powder.

### DIFF
--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -193,7 +193,7 @@
     "skill_used": "fabrication",
     "difficulty": 3,
     "time": "4 m",
-    "charges": 200,
+    "charges": 2000,
     "autolearn": true,
     "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "GRIND", "level": 1 } ],
     "components": [

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -186,6 +186,24 @@
   },
   {
     "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
+    "result": "chem_zinc_powder",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_OTHER",
+    "skill_used": "fabrication",
+    "difficulty": 3,
+    "time": "5 m",
+    "charges": 200,
+    "autolearn": true,
+    "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "GRIND", "level": 1 } ],
+    "components": [
+      [ [ "metal_zinc", 200 ] ],
+      [ [ "water", 2 ], [ "water_clean", 2 ] ],
+      [ [ "material_sand", 10 ] ]
+    ]
+  },
+  {
+    "type": "recipe",
     "activity_level": "fake",
     "result": "ash",
     "category": "CC_OTHER",

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -192,14 +192,14 @@
     "subcategory": "CSC_OTHER_OTHER",
     "skill_used": "fabrication",
     "difficulty": 3,
-    "time": "5 m",
+    "time": "4 m",
     "charges": 200,
     "autolearn": true,
     "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "GRIND", "level": 1 } ],
     "components": [
-      [ [ "metal_zinc", 200 ] ],
-      [ [ "water", 2 ], [ "water_clean", 2 ] ],
-      [ [ "material_sand", 10 ] ]
+      [ [ "zinc_metal", 200 ] ],
+      [ [ "water", 3 ], [ "water_clean", 3 ] ],
+      [ [ "material_sand", 15 ] ]
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Adds a recipe to grind zinc into zinc powder
<!-- This section should consist of exactly one line, edit the one above.
Category must be one of these: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N. Or replace the whole line with just the word None for no changelog entry.
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Currently the only way to acquire zinc powder is to make it from zinc oxide, a by-product of refining zinc from zincite. Zinc itself can only be used to make batteries, despite the description of the item even indicating that it can be ground into a useful powder.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
One unit of zinc powder in-game is equal by mass to 11 units of zinc. The recipe calls for 200 zinc (the amount the player gets from refining one chunk of zincite) to be ground into 2000 zinc powder. There's a bit of a loss there, perhaps to be expected in the process of grinding the metal down. I used the recipe for grinding aluminum down as a reference and adjusted the time and materials required according to relative mass. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Possibly letting the player disassemble the zinc itself, but the crafting system seems much better optimized for the amounts involved compared to the disassembly menu.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I've tested and confirmed that the recipe works with my own copy of the game.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
